### PR TITLE
get existing user by email and and by the network identifier

### DIFF
--- a/controllers/social/controller.php
+++ b/controllers/social/controller.php
@@ -71,11 +71,8 @@ class SocialController extends Controller
 
     protected function do_login()
     {
-        $ul = new UserList();
-        $ul->filterByAttribute("{$this->network}_id", $this->user->identifier);
-
-        $list = $ul->get(1);
-        $user = $list[0];
+        $ui = UserInfo::getByEmail($this->user->email);
+        
         $response = false;
 
         if ($user != null) {
@@ -96,7 +93,7 @@ class SocialController extends Controller
             'uName' => $uName,
             'uPassword' => $rand,
             'uPasswordConfirm' => $rand,
-            'uEmail' => "{$rand}.social.registration@noemail.com",
+            'uEmail' => $this->user->email,
         );
 
         if ($ui = UserInfo::register($uData)) {


### PR DESCRIPTION
getting the network identifier isn't always easy and in case you only want your users to login and not register you'll have a hard time setting them up in advance.

if we match by email address we can manually create the users first and then allow our users to login using google or whatnow.